### PR TITLE
Add filter-subscribe protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # waku-oxidized
+
+[Waku](https://waku.org) [light node](https://docs.waku.org/learn/glossary#light-node) implementing the following Waku protocols:
+
+- [peer exchange](https://github.com/waku-org/specs/blob/master/standards/core/peer-exchange.md)
+- [filter](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/12/filter.md)
+- [light push](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/19/lightpush.md)

--- a/proto/filter.proto
+++ b/proto/filter.proto
@@ -29,7 +29,7 @@ message FilterSubscribeResponse {
 }
 
 // Protocol identifier: /vac/waku/filter-push/2.0.0-beta1
-message MessagePush {
-  waku.message.WakuMessage waku_message = 1;
-  optional string pubsub_topic = 2;
-}
+// message MessagePush {
+//   waku.message.WakuMessage waku_message = 1;
+//   optional string pubsub_topic = 2;
+// }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,85 @@
+use async_trait::async_trait;
+use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use libp2p::{request_response, StreamProtocol};
+use prost::Message;
+use std::io;
+
+// TODO check what these should be
+const MAX_FILTER_RPC_SIZE: u64 = 1024 * 1024 * 1024;
+
+pub mod messages {
+    include!(concat!(env!("OUT_DIR"), "/waku.filter.v2.rs"));
+}
+
+// pub mod message {
+//     use crate::light_push::message::WakuMessage;
+// }
+
+// pub mod message {
+//     include!(concat!(env!("OUT_DIR"), "/waku.message.rs"));
+// }
+
+#[derive(Clone, Default)]
+pub struct Codec {}
+
+#[async_trait]
+impl request_response::Codec for Codec {
+    type Protocol = StreamProtocol;
+    type Request = messages::FilterSubscribeRequest;
+    type Response = messages::FilterSubscribeResponse;
+
+    async fn read_request<T>(&mut self, _: &Self::Protocol, io: &mut T) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let mut vec = Vec::with_capacity(MAX_FILTER_RPC_SIZE as usize);
+        io.read_to_end(&mut vec).await?;
+        let request = Self::Request::decode_length_delimited(&vec[..])?;
+        Ok(request)
+    }
+
+    async fn read_response<T>(
+        &mut self,
+        _: &Self::Protocol,
+        io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let mut vec = Vec::with_capacity(MAX_FILTER_RPC_SIZE as usize);
+
+        io.read_to_end(&mut vec).await?;
+        let response = Self::Response::decode_length_delimited(&vec[..])?;
+        Ok(response)
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        _: &Self::Protocol,
+        io: &mut T,
+        req: Self::Request,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        let buf = req.encode_length_delimited_to_vec();
+        io.write_all(buf.as_ref()).await?;
+
+        Ok(())
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        _: &Self::Protocol,
+        io: &mut T,
+        resp: Self::Response,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        let buf = resp.encode_length_delimited_to_vec();
+        io.write_all(buf.as_ref()).await?;
+
+        Ok(())
+    }
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -11,13 +11,9 @@ pub mod messages {
     include!(concat!(env!("OUT_DIR"), "/waku.filter.v2.rs"));
 }
 
-// pub mod message {
-//     use crate::light_push::message::WakuMessage;
-// }
+pub const PROTOCOL_NAME: &str = "/vac/waku/filter-subscribe/2.0.0-beta1";
 
-// pub mod message {
-//     include!(concat!(env!("OUT_DIR"), "/waku.message.rs"));
-// }
+pub use messages::*;
 
 #[derive(Clone, Default)]
 pub struct Codec {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,14 @@ use std::{
 const DEFAULT_PUBSUB_TOPIC: &str = "/waku/2/default-waku/proto";
 
 pub struct WakuLightNodeConfig {
+    /// Initial nodes to connect to
     pub peers: Vec<Multiaddr>,
+    /// A libp2p identity keypair
     pub keypair: Keypair,
 }
 
 impl WakuLightNodeConfig {
+    /// Create config, generating a keypair unless one is given
     pub fn new(keypair: Option<Keypair>, peers: Vec<Multiaddr>) -> Self {
         Self {
             keypair: keypair.unwrap_or(Keypair::generate_ed25519()),
@@ -49,7 +52,7 @@ impl WakuLightNode {
             )?
             .with_dns()?
             .with_behaviour(|_key| WakuLightNodeBehaviour::new())
-            .unwrap()
+            .unwrap() // Infalliable
             .with_swarm_config(|config| {
                 config
                     .with_notify_handler_buffer_size(
@@ -76,6 +79,7 @@ impl WakuLightNode {
         );
     }
 
+    /// Send a Waku message
     pub fn send_message(
         &mut self,
         peer: &PeerId,
@@ -107,14 +111,28 @@ impl WakuLightNode {
         Ok(())
     }
 
+    /// Subscribe to topic(s) using the filter protocol
     pub fn filter_subscribe(&mut self, peer: &PeerId, content_topics: Vec<String>) {
+        self.swarm.behaviour_mut().filter.send_request(
+            peer,
+            filter::FilterSubscribeRequest {
+                pubsub_topic: Some(DEFAULT_PUBSUB_TOPIC.to_string()),
+                content_topics,
+                request_id: "0".to_string(),
+                filter_subscribe_type: FilterSubscribeType::Subscribe as i32,
+            },
+        );
+    }
+
+    /// Unsubscribe from topic(s) using the filter protocol
+    pub fn filter_unsubscribe(&mut self, peer: &PeerId, content_topics: Vec<String>) {
         self.swarm.behaviour_mut().filter.send_request(
             peer,
             filter::messages::FilterSubscribeRequest {
                 pubsub_topic: Some(DEFAULT_PUBSUB_TOPIC.to_string()),
                 content_topics,
                 request_id: "0".to_string(),
-                filter_subscribe_type: FilterSubscribeType::Subscribe as i32,
+                filter_subscribe_type: FilterSubscribeType::Unsubscribe as i32,
             },
         );
     }
@@ -134,28 +152,28 @@ impl WakuLightNodeBehaviour {
         Self {
             peer_exchange: request_response::Behaviour::new(
                 [(
-                    StreamProtocol::new("/vac/waku/peer-exchange/2.0.0-alpha1"),
+                    StreamProtocol::new(peer_exchange::PROTOCOL_NAME),
                     request_response::ProtocolSupport::Full,
                 )],
                 request_response::Config::default(),
             ),
             metadata: request_response::Behaviour::new(
                 [(
-                    StreamProtocol::new("/vac/waku/metadata/1.0.0"),
+                    StreamProtocol::new(metadata::PROTOCOL_NAME),
                     request_response::ProtocolSupport::Full,
                 )],
                 request_response::Config::default(),
             ),
             light_push: request_response::Behaviour::new(
                 [(
-                    StreamProtocol::new("/vac/waku/lightpush/2.0.0-beta1"),
+                    StreamProtocol::new(light_push::PROTOCOL_NAME),
                     request_response::ProtocolSupport::Full,
                 )],
                 request_response::Config::default(),
             ),
             filter: request_response::Behaviour::new(
                 [(
-                    StreamProtocol::new("/vac/waku/filter-subscribe/2.0.0-beta1"),
+                    StreamProtocol::new(filter::PROTOCOL_NAME),
                     request_response::ProtocolSupport::Full,
                 )],
                 request_response::Config::default(),
@@ -164,6 +182,7 @@ impl WakuLightNodeBehaviour {
     }
 }
 
+/// An event from one of the Waku light node protocols
 #[derive(Debug)]
 pub enum WakuLightNodeEvent {
     PeerExchange(
@@ -255,6 +274,8 @@ impl From<request_response::Event<light_push::messages::PushRpc, light_push::mes
         Self::LightPush(event)
     }
 }
+
+/// Error when setting up or running a light node
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Multiaddr: {0}")]

--- a/src/light_push.rs
+++ b/src/light_push.rs
@@ -17,8 +17,6 @@ pub mod message {
 
 pub const PROTOCOL_NAME: &str = "/vac/waku/lightpush/2.0.0-beta1";
 
-pub use messages::*;
-
 #[derive(Clone, Default)]
 pub struct Codec {}
 

--- a/src/light_push.rs
+++ b/src/light_push.rs
@@ -15,6 +15,10 @@ pub mod message {
     include!(concat!(env!("OUT_DIR"), "/waku.message.rs"));
 }
 
+pub const PROTOCOL_NAME: &str = "/vac/waku/lightpush/2.0.0-beta1";
+
+pub use messages::*;
+
 #[derive(Clone, Default)]
 pub struct Codec {}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ async fn main() -> anyhow::Result<()> {
                 Some(SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. }) => {
                     println!("Connection estabilished with {peer_id:?} on {endpoint:?}");
                     node.request_peers(&peer_id);
+                    node.filter_subscribe(&peer_id, vec![cli.topic.clone()]);
                     node.send_message(&peer_id, cli.topic.clone(), cli.message.clone().into())?;
                 }
                 None => {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -16,8 +16,6 @@ pub mod messages {
 
 pub const PROTOCOL_NAME: &str = "/vac/waku/metadata/1.0.0";
 
-pub use messages::*;
-
 #[derive(Clone, Default)]
 pub struct Codec {}
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -14,6 +14,10 @@ pub mod messages {
     include!(concat!(env!("OUT_DIR"), "/waku.metadata.rs"));
 }
 
+pub const PROTOCOL_NAME: &str = "/vac/waku/metadata/1.0.0";
+
+pub use messages::*;
+
 #[derive(Clone, Default)]
 pub struct Codec {}
 

--- a/src/peer_exchange.rs
+++ b/src/peer_exchange.rs
@@ -17,8 +17,6 @@ pub mod messages {
     include!(concat!(env!("OUT_DIR"), "/peer_exchange.rs"));
 }
 
-pub use messages::*;
-
 #[derive(Clone, Default)]
 pub struct Codec {}
 

--- a/src/peer_exchange.rs
+++ b/src/peer_exchange.rs
@@ -1,3 +1,4 @@
+//! Codec for the peer-exchange protocol
 use async_trait::async_trait;
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::{request_response, StreamProtocol};
@@ -10,9 +11,13 @@ const REQUEST_SIZE_MAXIMUM: u64 = 1024 * 1024;
 /// Max response size in bytes
 const RESPONSE_SIZE_MAXIMUM: u64 = 10 * 1024 * 1024;
 
+pub const PROTOCOL_NAME: &str = "/vac/waku/peer-exchange/2.0.0-alpha1";
+
 pub mod messages {
     include!(concat!(env!("OUT_DIR"), "/peer_exchange.rs"));
 }
+
+pub use messages::*;
 
 #[derive(Clone, Default)]
 pub struct Codec {}


### PR DESCRIPTION
This adds the filter-subscribe request-response protocol.

But we do not yet actually handle messages.  That requires the `filter-push`:
https://github.com/LesnyRumcajs/waku-oxidized/blob/b0adc08d75f940e6334b69e1d384c54c30e82e70/proto/filter.proto#L32 

which works a little bit differently because it is not a request-response protocol - the server just pushes messages to the client. I am not sure how to create this behavior and register the protocol.